### PR TITLE
replace request() with request()->query() on FilterScope and SearchScope

### DIFF
--- a/app/Scopes/FilterScope.php
+++ b/app/Scopes/FilterScope.php
@@ -16,7 +16,7 @@ class FilterScope implements Scope
 
         foreach($columns as $column)
         {
-            if ($value = request($column)) {
+            if ($value = request()->query($column)) {
                 $builder->where($column, $value);
             }
         }

--- a/app/Scopes/SearchScope.php
+++ b/app/Scopes/SearchScope.php
@@ -12,7 +12,7 @@ class SearchScope implements Scope
 
     public function apply(Builder $builder, Model $model)
     {
-        if ($search = request('search')) 
+        if ($search = request()->query('search')) 
         {
             $columns = property_exists($model, 'searchColumns') ? $model->searchColumns : $this->searchColumns;
             


### PR DESCRIPTION
I'll replace the `request()` helper call with `request()->query()` because `request()` will capture data that we sent whether from the form or from query string. While `request()->query()` will  capture data only from query string.